### PR TITLE
feat: add buffer files count metrics

### DIFF
--- a/buffer-size.sh
+++ b/buffer-size.sh
@@ -3,10 +3,17 @@
 [ -z "$BUFFER_PATH" ] && BUFFER_PATH=/buffers
 
 while true; do
-    echo "# HELP node_buffer_size_bytes Disk space used" > /prometheus/node_exporter/textfile_collector/buffer_size.prom
+    # Deprecated: node_buffer_size_bytes will soon be replaced by logging_node_agent_buffer_size_bytes
+    # logging_node_agent_buffer_size_bytes includes the host label
+    echo "# HELP node_buffer_size_bytes Disk space used [deprecated]" > /prometheus/node_exporter/textfile_collector/buffer_size.prom
     echo "# TYPE node_buffer_size_bytes gauge" >> /prometheus/node_exporter/textfile_collector/buffer_size.prom
     du -sb ${BUFFER_PATH} | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/node_buffer_size_bytes{entity="\2"} \1/p' >> /prometheus/node_exporter/textfile_collector/buffer_size.prom.$$
     mv /prometheus/node_exporter/textfile_collector/buffer_size.prom.$$ /prometheus/node_exporter/textfile_collector/buffer_size.prom
+
+    echo "# HELP logging_node_agent_buffer_size_bytes Disk space used" > /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_size_bytes.prom
+    echo "# TYPE logging_node_agent_buffer_size_bytes gauge" >> /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_size_bytes.prom
+    du -sb ${BUFFER_PATH} | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/logging_node_agent_buffer_size_bytes{entity="\2", host="'$(hostname)'"} \1/p' >> /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_size_bytes.prom.$$
+    mv /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_size_bytes.prom.$$ /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_size_bytes.prom
 
     sleep 60
 done

--- a/buffer-size.sh
+++ b/buffer-size.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
-while true; do
-
-echo "# HELP node_buffer_size_bytes Disk space used" > /prometheus/node_exporter/textfile_collector/buffer_size.prom
-echo "# TYPE node_buffer_size_bytes gauge" >> /prometheus/node_exporter/textfile_collector/buffer_size.prom
-
 [ -z "$BUFFER_PATH" ] && BUFFER_PATH=/buffers
-du -sb ${BUFFER_PATH} | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/node_buffer_size_bytes{entity="\2"} \1/p' >> /prometheus/node_exporter/textfile_collector/buffer_size.prom
 
-sleep 60
+while true; do
+    echo "# HELP node_buffer_size_bytes Disk space used" > /prometheus/node_exporter/textfile_collector/buffer_size.prom
+    echo "# TYPE node_buffer_size_bytes gauge" >> /prometheus/node_exporter/textfile_collector/buffer_size.prom
+    du -sb ${BUFFER_PATH} | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/node_buffer_size_bytes{entity="\2"} \1/p' >> /prometheus/node_exporter/textfile_collector/buffer_size.prom.$$
+    mv /prometheus/node_exporter/textfile_collector/buffer_size.prom.$$ /prometheus/node_exporter/textfile_collector/buffer_size.prom
+
+    sleep 60
 done

--- a/buffer-size.sh
+++ b/buffer-size.sh
@@ -20,5 +20,5 @@ while true; do
     echo -e "$(find "${BUFFER_PATH}" -type f 2>/dev/null | wc -l)\t${BUFFER_PATH}" | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/logging_buffer_files{entity="\2", host="'$(hostname)'"} \1/p' >> /prometheus/node_exporter/textfile_collector/logging_buffer_files.prom.$$
     mv /prometheus/node_exporter/textfile_collector/logging_buffer_files.prom.$$ /prometheus/node_exporter/textfile_collector/logging_buffer_files.prom
 
-    sleep 30
+    sleep 15
 done

--- a/buffer-size.sh
+++ b/buffer-size.sh
@@ -15,5 +15,10 @@ while true; do
     du -sb ${BUFFER_PATH} | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/logging_node_agent_buffer_size_bytes{entity="\2", host="'$(hostname)'"} \1/p' >> /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_size_bytes.prom.$$
     mv /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_size_bytes.prom.$$ /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_size_bytes.prom
 
+    echo "# HELP logging_node_agent_buffer_files File count" > /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_files.prom
+    echo "# TYPE logging_node_agent_buffer_files gauge" >> /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_files.prom
+    echo -e "$(find "${BUFFER_PATH}" -type f 2>/dev/null | wc -l)\t${BUFFER_PATH}" | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/logging_node_agent_buffer_files{entity="\2", host="'$(hostname)'"} \1/p' >> /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_files.prom.$$
+    mv /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_files.prom.$$ /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_files.prom
+
     sleep 60
 done

--- a/buffer-size.sh
+++ b/buffer-size.sh
@@ -3,22 +3,22 @@
 [ -z "$BUFFER_PATH" ] && BUFFER_PATH=/buffers
 
 while true; do
-    # Deprecated: node_buffer_size_bytes will soon be replaced by logging_node_agent_buffer_size_bytes
-    # logging_node_agent_buffer_size_bytes includes the host label
+    # Deprecated: node_buffer_size_bytes will soon be replaced by logging_buffer_size_bytes
+    # logging_buffer_size_bytes includes the host label
     echo "# HELP node_buffer_size_bytes Disk space used [deprecated]" > /prometheus/node_exporter/textfile_collector/buffer_size.prom
     echo "# TYPE node_buffer_size_bytes gauge" >> /prometheus/node_exporter/textfile_collector/buffer_size.prom
     du -sb ${BUFFER_PATH} | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/node_buffer_size_bytes{entity="\2"} \1/p' >> /prometheus/node_exporter/textfile_collector/buffer_size.prom.$$
     mv /prometheus/node_exporter/textfile_collector/buffer_size.prom.$$ /prometheus/node_exporter/textfile_collector/buffer_size.prom
 
-    echo "# HELP logging_node_agent_buffer_size_bytes Disk space used" > /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_size_bytes.prom
-    echo "# TYPE logging_node_agent_buffer_size_bytes gauge" >> /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_size_bytes.prom
-    du -sb ${BUFFER_PATH} | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/logging_node_agent_buffer_size_bytes{entity="\2", host="'$(hostname)'"} \1/p' >> /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_size_bytes.prom.$$
-    mv /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_size_bytes.prom.$$ /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_size_bytes.prom
+    echo "# HELP logging_buffer_size_bytes Disk space used" > /prometheus/node_exporter/textfile_collector/logging_buffer_size_bytes.prom
+    echo "# TYPE logging_buffer_size_bytes gauge" >> /prometheus/node_exporter/textfile_collector/logging_buffer_size_bytes.prom
+    du -sb ${BUFFER_PATH} | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/logging_buffer_size_bytes{entity="\2", host="'$(hostname)'"} \1/p' >> /prometheus/node_exporter/textfile_collector/logging_buffer_size_bytes.prom.$$
+    mv /prometheus/node_exporter/textfile_collector/logging_buffer_size_bytes.prom.$$ /prometheus/node_exporter/textfile_collector/logging_buffer_size_bytes.prom
 
-    echo "# HELP logging_node_agent_buffer_files File count" > /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_files.prom
-    echo "# TYPE logging_node_agent_buffer_files gauge" >> /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_files.prom
-    echo -e "$(find "${BUFFER_PATH}" -type f 2>/dev/null | wc -l)\t${BUFFER_PATH}" | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/logging_node_agent_buffer_files{entity="\2", host="'$(hostname)'"} \1/p' >> /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_files.prom.$$
-    mv /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_files.prom.$$ /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_files.prom
+    echo "# HELP logging_buffer_files File count" > /prometheus/node_exporter/textfile_collector/logging_buffer_files.prom
+    echo "# TYPE logging_buffer_files gauge" >> /prometheus/node_exporter/textfile_collector/logging_buffer_files.prom
+    echo -e "$(find "${BUFFER_PATH}" -type f 2>/dev/null | wc -l)\t${BUFFER_PATH}" | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/logging_buffer_files{entity="\2", host="'$(hostname)'"} \1/p' >> /prometheus/node_exporter/textfile_collector/logging_buffer_files.prom.$$
+    mv /prometheus/node_exporter/textfile_collector/logging_buffer_files.prom.$$ /prometheus/node_exporter/textfile_collector/logging_buffer_files.prom
 
     sleep 30
 done

--- a/buffer-size.sh
+++ b/buffer-size.sh
@@ -20,5 +20,5 @@ while true; do
     echo -e "$(find "${BUFFER_PATH}" -type f 2>/dev/null | wc -l)\t${BUFFER_PATH}" | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/logging_node_agent_buffer_files{entity="\2", host="'$(hostname)'"} \1/p' >> /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_files.prom.$$
     mv /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_files.prom.$$ /prometheus/node_exporter/textfile_collector/logging_node_agent_buffer_files.prom
 
-    sleep 60
+    sleep 30
 done


### PR DESCRIPTION
- Deprecate `node_buffer_size_bytes`.
- Introduce `logging_buffer_size_bytes` that includes the `host` label.
- Introduce `logging_buffer_files` that tracks file count.
- Reduce metrics update interval from 60s to 15s.
