### PR TITLE
fix: reduce node_buffer_size_bytes cardinality

### DIFF
--- a/buffer-size.sh
+++ b/buffer-size.sh
@@ -6,7 +6,7 @@ echo "# HELP node_buffer_size_bytes Disk space used" > /prometheus/node_exporter
 echo "# TYPE node_buffer_size_bytes gauge" >> /prometheus/node_exporter/textfile_collector/buffer_size.prom
 
 [ -z "$BUFFER_PATH" ] && BUFFER_PATH=/buffers
-du -ab ${BUFFER_PATH} | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/node_buffer_size_bytes{entity="\2"} \1/p' >> /prometheus/node_exporter/textfile_collector/buffer_size.prom
+du -sb ${BUFFER_PATH} | sed -ne 's/\\/\\\\/;s/"/\\"/g;s/^\([0-9]\+\)\t\(.*\)$/node_buffer_size_bytes{entity="\2"} \1/p' >> /prometheus/node_exporter/textfile_collector/buffer_size.prom
 
 sleep 60
 done


### PR DESCRIPTION
Reduce metrics cardinality. Currently, each file/folder with a new name creates a new serie. Change it so only the grand total of the buffer directory is exported as a serie.


Before: N series per fluentbit

```
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.254.37:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-rvzcp", service="logging-operator-logging-fluentbit-buffer-metrics"} | 24576
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.254.5:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-v8b4h", service="logging-operator-logging-fluentbit-buffer-metrics"} | 24576
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.5.230:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-8tqpp", service="logging-operator-logging-fluentbit-buffer-metrics"} | 114688
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.5.231:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-6d8dm", service="logging-operator-logging-fluentbit-buffer-metrics"} | 24576
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.5.232:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-smlfw", service="logging-operator-logging-fluentbit-buffer-metrics"} | 24576
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.5.233:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-42j9d", service="logging-operator-logging-fluentbit-buffer-metrics"} | 28672
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.5.234:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-85mhv", service="logging-operator-logging-fluentbit-buffer-metrics"} | 24576
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.5.235:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-hjtcg", service="logging-operator-logging-fluentbit-buffer-metrics"} | 24576
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.5.53:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-wgzbs", service="logging-operator-logging-fluentbit-buffer-metrics"} | 126976
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.25.129.135:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-xg6lk", service="logging-operator-logging-fluentbit-buffer-metrics"} | 24576
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/lost+found", instance="10.23.254.37:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-rvzcp", service="logging-operator-logging-fluentbit-buffer-metrics"} | 16384
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/lost+found", instance="10.23.254.5:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-v8b4h", service="logging-operator-logging-fluentbit-buffer-metrics"} | 16384
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/lost+found", instance="10.23.5.230:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-8tqpp", service="logging-operator-logging-fluentbit-buffer-metrics"} | 16384
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/lost+found", instance="10.23.5.231:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-6d8dm", service="logging-operator-logging-fluentbit-buffer-metrics"} | 16384
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/lost+found", instance="10.23.5.232:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-smlfw", service="logging-operator-logging-fluentbit-buffer-metrics"} | 16384
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/lost+found", instance="10.23.5.233:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-42j9d", service="logging-operator-logging-fluentbit-buffer-metrics"} | 16384
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/lost+found", instance="10.23.5.234:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-85mhv", service="logging-operator-logging-fluentbit-buffer-metrics"} | 16384
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/lost+found", instance="10.23.5.235:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-hjtcg", service="logging-operator-logging-fluentbit-buffer-metrics"} | 16384
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/lost+found", instance="10.23.5.53:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-wgzbs", service="logging-operator-logging-fluentbit-buffer-metrics"} | 16384
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/lost+found", instance="10.25.129.135:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-xg6lk", service="logging-operator-logging-fluentbit-buffer-metrics"} | 16384
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/tail.0", instance="10.23.254.37:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-rvzcp", service="logging-operator-logging-fluentbit-buffer-metrics"} | 4096
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/tail.0", instance="10.23.254.5:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-v8b4h", service="logging-operator-logging-fluentbit-buffer-metrics"} | 4096
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/tail.0", instance="10.23.5.230:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-8tqpp", service="logging-operator-logging-fluentbit-buffer-metrics"} | 94208
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/tail.0", instance="10.23.5.231:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-6d8dm", service="logging-operator-logging-fluentbit-buffer-metrics"} | 4096
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/tail.0", instance="10.23.5.232:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-smlfw", service="logging-operator-logging-fluentbit-buffer-metrics"} | 4096
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/tail.0", instance="10.23.5.233:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-42j9d", service="logging-operator-logging-fluentbit-buffer-metrics"} | 8192
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/tail.0", instance="10.23.5.234:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-85mhv", service="logging-operator-logging-fluentbit-buffer-metrics"} | 4096
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/tail.0", instance="10.23.5.235:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-hjtcg", service="logging-operator-logging-fluentbit-buffer-metrics"} | 4096
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/tail.0", instance="10.23.5.53:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-wgzbs", service="logging-operator-logging-fluentbit-buffer-metrics"} | 106496
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers/tail.0", instance="10.25.129.135:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-xg6lk", service="logging-operator-logging-fluentbit-buffer-metrics"} | 135168
```

After: 1 serie per fluentbit

```
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.5.232:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-smlfw", service="logging-operator-logging-fluentbit-buffer-metrics"} | 28672
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.5.231:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-6d8dm", service="logging-operator-logging-fluentbit-buffer-metrics"} | 24576
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.5.230:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-8tqpp", service="logging-operator-logging-fluentbit-buffer-metrics"} | 69632
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.25.129.135:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-xg6lk", service="logging-operator-logging-fluentbit-buffer-metrics"} | 24576
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.254.37:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-rvzcp", service="logging-operator-logging-fluentbit-buffer-metrics"} | 24576
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.254.5:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-v8b4h", service="logging-operator-logging-fluentbit-buffer-metrics"} | 24576
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.5.233:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-42j9d", service="logging-operator-logging-fluentbit-buffer-metrics"} | 28672
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.5.53:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-wgzbs", service="logging-operator-logging-fluentbit-buffer-metrics"} | 159744
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.5.234:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-85mhv", service="logging-operator-logging-fluentbit-buffer-metrics"} | 24576
node_buffer_size_bytes{container="buffer-metrics-sidecar", endpoint="buffer-metrics", entity="/buffers", instance="10.23.5.235:9200", job="logging-operator-logging-fluentbit-buffer-metrics", namespace="logging", pod="logging-operator-logging-fluentbit-hjtcg", service="logging-operator-logging-fluentbit-buffer-metrics"} | 24576
```
